### PR TITLE
switch pm3 client submodule to rrg repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "pm3rdv4rrg/src/main/cpp/proxmark3"]
 	path = pm3rdv4rrg/src/main/cpp/proxmark3
-	url = https://github.com/xianglin1998/proxmark3.git
+	url = https://github.com/RfidResearchGroup/proxmark3.git
 [submodule "pm3rdv4rrg/src/main/cpp/bzip2"]
 	path = pm3rdv4rrg/src/main/cpp/bzip2
 	url = http://sourceware.org/git/bzip2.git


### PR DESCRIPTION
update pm3 client verion.
once I build success and installed on my phone,it still an old version pm3 client in the termux view and I dont know why.