### PR TITLE
Don't break on auto-refusal of Storage permissions on high Android versions

### DIFF
--- a/apprts/src/main/java/com/rfidresearchgroup/activities/tools/LoginActivity.java
+++ b/apprts/src/main/java/com/rfidresearchgroup/activities/tools/LoginActivity.java
@@ -96,11 +96,13 @@ public class LoginActivity
         });
 
         ArrayList<String> permissionArray = new ArrayList<>();
-        Collections.addAll(permissionArray,
-                // 以下是一定要添加的权限
-                Manifest.permission.WRITE_EXTERNAL_STORAGE,
-                Manifest.permission.READ_EXTERNAL_STORAGE
-        );
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            Collections.addAll(permissionArray,
+                    // 以下是一定要添加的权限
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE,
+                    Manifest.permission.READ_EXTERNAL_STORAGE
+            );
+        }
 
         // android 12或者以上，要单独申请蓝牙权限
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {


### PR DESCRIPTION
These permissions would be auto-refused on A13, leading to the app refusing to start with an error message like "you have not granted the requested permissions".

I've found that the app works mostly fine without these perms, at least as far as proxmark is concerned.
I've conditioned that on `Build.VERSION_CODES.R` because the Manifest's warning did say these permissions are ignored and have no effect on versions >= `R`.