### PR TITLE
Fix getlocaledecpoint error

### DIFF
--- a/libflasher/src/main/cpp/CMakeLists.txt
+++ b/libflasher/src/main/cpp/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.4.1)
 add_definitions("-D__ANDROID_NDK__")
 
 #添加预编译宏定义参数，此次的作用是开启配置文件的引入!
-add_definitions(-DANDROID -D "getlocaledecpoint()='.'")
+add_definitions(-DANDROID)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99 -O3 -fvisibility=hidden -w")
 


### PR DESCRIPTION
The CmakeLists.txt file of libflasher contains an obsolete reference to the lua macro `getlocaledecpoint()` that was removed some years ago in commit b81852de62db1ec453dbfc54381357a4db038fe1.
The brackets are interpreted by sh when building on unix, causing compilation errors.

This pull requests removes the reference as it is not required anymore.
This should fix https://github.com/RfidResearchGroup/RFIDtools/issues/70